### PR TITLE
improvement: reversing events array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export default async function run() {
 
 	const events = data?.eventos || [];
 
-	events?.forEach((event) => {
+	events?.reverse().forEach((event) => {
 		const { descricao, descricaoWeb, dtHrCriado, unidade, unidadeDestino } = event;
 
 		log(`==> ${getIcon(descricaoWeb)} ${descricao}`);


### PR DESCRIPTION
Fala mano! Abri essa PR mais por uma questão de usabilidade. Fui usar ele hoje e percebi que os eventos estão sendo printados do evento mais recente para o mais antigo. Mas como usamos ele no terminal e não na web por exemplo, nosso input é feito na parte de "baixo", então nesse caso a usabilidade ficaria melhor se os eventos fossem printados do mais antigo para o mais recente evento. (seguindo a lógica de um `heroku logs --tail` por exemplo.

No meu caso, com o array ordenado sem um reverse() tive que dar um scroll até o inicio para ver o evento mais recente. Já adicionar um reverse() não preciso dar esse scroll no terminal por exemplo ;)

Me diz ai o que acha!
